### PR TITLE
feat: add kelvin unit (temperature)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdc-unit-converter"
-version = "0.1.0"
+version = "0.2.0"
 description = "A flexible unit conversion library for scientific and engineering use"
 authors = ["Ariel Cabello <acabello@fdc-group.com>"
 ]

--- a/src/fdc_unit_converter/unit_converter.py
+++ b/src/fdc_unit_converter/unit_converter.py
@@ -402,13 +402,21 @@ class UnitConverter:
             f = {
                 # From celsius
                 (units.celsius, units.fahrenheit): value * 9 / 5 + 32,
+                (units.celsius, units.kelvin): value + 273.15,
 
                 # From fahrenheit
                 (units.fahrenheit, units.celsius): (value - 32) * 5 / 9,
                 (units.fahrenheit, units.rankine): value + 459.67,
+                (units.fahrenheit, units.kelvin): (value - 32) * 5 / 9 + 273.15,
 
                 # From rankine
                 (units.rankine, units.celsius): (value - 491.67) * 5 / 9,
+                (units.rankine, units.kelvin): value * 5 / 9,
+
+                # From kelvin
+                (units.kelvin, units.celsius): value - 273.15,
+                (units.kelvin, units.fahrenheit): (value - 273.15) * 9 / 5 + 32,
+                (units.kelvin, units.rankine): value * 9 / 5,
             }
             return f[from_to]
         # fmt: on

--- a/src/fdc_unit_converter/units.py
+++ b/src/fdc_unit_converter/units.py
@@ -98,6 +98,7 @@ thousand_standard_cubic_feet_per_day = Unit("thousand standard cubic feet per da
 celsius = Unit("celsius", "°C", Magnitude.TEMPERATURE)
 fahrenheit = Unit("fahrenheit", "°F", Magnitude.TEMPERATURE)
 rankine = Unit("rankine", "°R", Magnitude.TEMPERATURE)
+kelvin = Unit("kelvin", "K", Magnitude.TEMPERATURE)
 
 # Time
 second = Unit("second", "s", Magnitude.TIME)

--- a/tests/test_unit_converter.py
+++ b/tests/test_unit_converter.py
@@ -36,6 +36,34 @@ def test_temperature_rankine_to_c():
     assert result == pytest.approx(0.0)
 
 
+def test_temperature_c_to_k():
+    assert UnitConverter.convert(0, units.celsius, units.kelvin) == pytest.approx(273.15)
+
+
+def test_temperature_k_to_c():
+    assert UnitConverter.convert(273.15, units.kelvin, units.celsius) == pytest.approx(0.0)
+
+
+def test_temperature_k_to_f():
+    # 0K = -459.67°F (absolute zero)
+    assert UnitConverter.convert(0, units.kelvin, units.fahrenheit) == pytest.approx(-459.67)
+
+
+def test_temperature_f_to_k():
+    # -459.67°F = 0K
+    assert UnitConverter.convert(-459.67, units.fahrenheit, units.kelvin) == pytest.approx(0.0)
+
+
+def test_temperature_k_to_r():
+    # 0K = 0°R
+    assert UnitConverter.convert(0, units.kelvin, units.rankine) == pytest.approx(0.0)
+
+
+def test_temperature_r_to_k():
+    # 0°R = 0K
+    assert UnitConverter.convert(0, units.rankine, units.kelvin) == pytest.approx(0.0)
+
+
 # ------------------------------
 # Pressure conversions
 # ------------------------------


### PR DESCRIPTION
This pull request adds support for Kelvin temperature conversions to the unit converter library. It introduces the Kelvin unit, implements conversion formulas between Kelvin and other temperature units, and adds comprehensive tests to ensure correctness of these conversions. The version number is also incremented to reflect these new features.

**Temperature unit enhancements:**

* Added the `kelvin` unit to the list of supported temperature units in `units.py`.
* Implemented conversion formulas between Kelvin and Celsius, Fahrenheit, and Rankine in `unit_converter.py`.

**Testing improvements:**

* Added tests for conversions between Kelvin and other temperature units in `test_unit_converter.py`.

**Version update:**

* Bumped the package version to `0.2.0` in `pyproject.toml` to reflect the new functionality.